### PR TITLE
ci: added workflow for housekeeping staled issues

### DIFF
--- a/.github/config/pr-labels.yaml
+++ b/.github/config/pr-labels.yaml
@@ -1,5 +1,7 @@
 builds:
 - head-branch: ['^build']
+- changed-files:
+  - any-glob-to-any-file: ['.docker/**/*']
 
 bugs:
 - head-branch: ['^fix/', '^hotfix/']
@@ -9,7 +11,7 @@ deploy:
 
 ci:
 - changed-files:
-  - any-glob-to-any-file: ['.github/**/*']
+  - any-glob-to-any-file: ['.github/**/*', 'renovate.json5']
 - head-branch: ['^ci/']
 
 deps:

--- a/.github/workflows/stale-issue.yaml
+++ b/.github/workflows/stale-issue.yaml
@@ -1,0 +1,26 @@
+name: Stale Issue
+
+on:
+  schedule:
+    # Runs on 23:30 JST every day, note that cron syntax applied as UTC
+    - cron: "30 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 3 days since being marked as staled."
+          stale-issue-label: "staled"
+          days-before-issue-stale: 14
+          days-before-issue-close: 3
+          # Does not apply for PRs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## Issue/PR link
relates: #27 

## What does this PR do?
Describe what changes you make in your branch:
- added workflow for housekeeping staled issues
- added rules to apply `builds` tag to file changes under `.docker/*`
- added rules to apply `ci` tag to file changes on renovate config

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A